### PR TITLE
Fixed client credentials flow

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -1060,7 +1060,8 @@ impl Client<UnAuthenticated, ClientCredsFlow, NoVerifier> {
         let token = oauth
             .exchange_client_credentials()
             .request_async(async_http_client)
-            .await?;
+            .await?
+            .set_timestamps();
 
         Ok(Client {
             auto_refresh: false,


### PR DESCRIPTION
I tried using this with [client credentials flow](https://github.com/domanteli0/event-map/blob/ac5ed92846b1cff4ef5af6f7f55f66443d8dbab2/back/src/main.rs), and I think proper expiration date was forgotten to set (appearantly my token expired in 1970 :) ).

I think this patch will fix it, since my fork works, at least for me.

Thanks for this crate, btw, otherwise its quite great.