### PR TITLE
AudioFeatures return type

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spotify-rs"
-version = "0.3.13"
+version = "0.3.14"
 edition = "2021"
 description = "A Rust wrapper for the Spotify API."
 readme = "README.md"

--- a/src/client.rs
+++ b/src/client.rs
@@ -641,7 +641,7 @@ impl<F: AuthFlow, V: Verifier> Client<Token, F, V> {
     pub async fn get_tracks_audio_features<T: AsRef<str>>(
         &mut self,
         ids: &[T],
-    ) -> Result<Vec<AudioFeatures>> {
+    ) -> Result<Vec<Option<AudioFeatures>>> {
         self.get("/audio-features".to_owned(), [("ids", query_list(ids))])
             .await
             .map(|a: AudioFeaturesResult| a.audio_features)

--- a/src/model/audio.rs
+++ b/src/model/audio.rs
@@ -27,7 +27,7 @@ pub struct AudioFeatures {
 
 #[derive(Clone, Debug, Deserialize)]
 pub(crate) struct AudioFeaturesResult {
-    pub(crate) audio_features: Vec<AudioFeatures>,
+    pub(crate) audio_features: Vec<Option<AudioFeatures>>,
 }
 
 #[derive(Clone, Debug, Deserialize)]


### PR DESCRIPTION
I just discovered that the documentation of the spotify api is not quite correct concerning the 'Get Several Tracks' Audio Features'. Namely, the returned result can contain `null` values when there are no audio features for a certain track.

This can easily be fixed by changing the return type to an `Option<_>`.

Be aware that the way I changed it is non-backwards compatible, so it's probably not good to merge it blindly. I still wanted to let you know and point out the necessary change. An easy way to make it backwards compatible is to add a new function which returns the correct result.