### PR TITLE
Add pagination

### DIFF
--- a/spotify-rs/src/client.rs
+++ b/spotify-rs/src/client.rs
@@ -28,7 +28,7 @@ use crate::{
 
 const AUTHORISATION_URL: &str = "https://accounts.spotify.com/authorize";
 const TOKEN_URL: &str = "https://accounts.spotify.com/api/token";
-const API_URL: &str = "https://api.spotify.com/v1";
+pub(crate) const API_URL: &str = "https://api.spotify.com/v1";
 
 pub(crate) type OAuthClient = oauth2::Client<
     BasicErrorResponse,

--- a/spotify-rs/src/client.rs
+++ b/spotify-rs/src/client.rs
@@ -240,7 +240,7 @@ impl<F: AuthFlow> Client<Token, F> {
 
             if deserialized.is_err() {
                 tracing::error!(
-                    body = std::str::from_utf8(&bytes).map_err(|_| Error::Http(
+                    body = %std::str::from_utf8(&bytes).map_err(|_| Error::Http(
                         "Error deserializing the response body to valid UTF-8.".to_owned()
                     ))?,
                     "Failed to deserialize the response body into an object or Nil."

--- a/spotify-rs/src/endpoint.rs
+++ b/spotify-rs/src/endpoint.rs
@@ -17,13 +17,23 @@ pub mod user;
 type Client<F> = crate::client::Client<crate::auth::Token, F>;
 
 #[doc = include_str!("docs/internal_implementation_details.md")]
-pub trait Endpoint: Serialize {}
+pub trait Endpoint: Serialize {
+    // This method isn't necessary, thus it's not implemented for all endpoints
+    // It's used for pagination, for keeping track of the current endpoint
+    // a `Page` refers to.
+    //
+    // However, in the future it might be implemented for all endpoints,
+    // for consistency's sake.
+    fn endpoint_url(&self) -> &'static str {
+        "TODO (default URL)"
+    }
+}
 
 impl<T: Endpoint> EndpointPrivate for T {}
 
 // Trait to add endpoint methods that make writing the endpoints
 // more convenient.
-pub(crate) trait EndpointPrivate: Serialize {
+pub(crate) trait EndpointPrivate: Serialize + Endpoint {
     // Convenience method used to convert a type (an endpoint in this case)
     // to a Body::Json.
     fn json(self) -> crate::client::Body<Self>

--- a/spotify-rs/src/endpoint/player.rs
+++ b/spotify-rs/src/endpoint/player.rs
@@ -23,7 +23,11 @@ impl Endpoint for SeekToPositionEndpoint {}
 impl Endpoint for SetRepeatModeEndpoint {}
 impl Endpoint for SetPlaybackVolumeEndpoint {}
 impl Endpoint for ToggleShuffleEndpoint {}
-impl<T: TimestampMarker> Endpoint for RecentlyPlayedTracksEndpoint<T> {}
+impl<T: TimestampMarker> Endpoint for RecentlyPlayedTracksEndpoint<T> {
+    fn endpoint_url(&self) -> &'static str {
+        "/me/player/recently-played"
+    }
+}
 impl Endpoint for AddItemToQueueEndpoint {}
 
 // authorised only
@@ -147,9 +151,7 @@ pub fn recently_played_tracks() -> RecentlyPlayedTracksEndpoint {
 }
 
 // authorised only
-pub async fn get_user_queue(
-    spotify: &Client<impl AuthFlow + Authorised>,
-) -> Result<Queue> {
+pub async fn get_user_queue(spotify: &Client<impl AuthFlow + Authorised>) -> Result<Queue> {
     spotify
         .get::<(), _>("/me/player/queue".to_owned(), None)
         .await
@@ -211,10 +213,7 @@ impl TransferPlaybackEndpoint {
     }
 
     #[doc = include_str!("../docs/send.md")]
-    pub async fn send(
-        self,
-        spotify: &Client<impl AuthFlow + Authorised>,
-    ) -> Result<Nil> {
+    pub async fn send(self, spotify: &Client<impl AuthFlow + Authorised>) -> Result<Nil> {
         spotify.put("/me/player".to_owned(), Body::Json(self)).await
     }
 }
@@ -261,10 +260,7 @@ impl StartPlaybackEndpoint {
     }
 
     #[doc = include_str!("../docs/send.md")]
-    pub async fn send(
-        self,
-        spotify: &Client<impl AuthFlow + Authorised>,
-    ) -> Result<Nil> {
+    pub async fn send(self, spotify: &Client<impl AuthFlow + Authorised>) -> Result<Nil> {
         let endpoint = match self.device_id {
             Some(ref id) => format!("/me/player/play?device_id={id}"),
             None => "/me/player/play".to_owned(),
@@ -288,10 +284,7 @@ impl SeekToPositionEndpoint {
     }
 
     #[doc = include_str!("../docs/send.md")]
-    pub async fn send(
-        self,
-        spotify: &Client<impl AuthFlow + Authorised>,
-    ) -> Result<Nil> {
+    pub async fn send(self, spotify: &Client<impl AuthFlow + Authorised>) -> Result<Nil> {
         spotify
             .request(Method::PUT, "/me/player/seek".to_owned(), self.into(), None)
             .await
@@ -312,10 +305,7 @@ impl SetRepeatModeEndpoint {
     }
 
     #[doc = include_str!("../docs/send.md")]
-    pub async fn send(
-        self,
-        spotify: &Client<impl AuthFlow + Authorised>,
-    ) -> Result<Nil> {
+    pub async fn send(self, spotify: &Client<impl AuthFlow + Authorised>) -> Result<Nil> {
         spotify
             .request(
                 Method::PUT,
@@ -341,10 +331,7 @@ impl SetPlaybackVolumeEndpoint {
     }
 
     #[doc = include_str!("../docs/send.md")]
-    pub async fn send(
-        self,
-        spotify: &Client<impl AuthFlow + Authorised>,
-    ) -> Result<Nil> {
+    pub async fn send(self, spotify: &Client<impl AuthFlow + Authorised>) -> Result<Nil> {
         spotify
             .request(
                 Method::PUT,
@@ -370,10 +357,7 @@ impl ToggleShuffleEndpoint {
     }
 
     #[doc = include_str!("../docs/send.md")]
-    pub async fn send(
-        self,
-        spotify: &Client<impl AuthFlow + Authorised>,
-    ) -> Result<Nil> {
+    pub async fn send(self, spotify: &Client<impl AuthFlow + Authorised>) -> Result<Nil> {
         spotify
             .request(
                 Method::PUT,
@@ -415,7 +399,7 @@ impl RecentlyPlayedTracksEndpoint<Unspecified> {
     }
 }
 
-impl<T: TimestampMarker> RecentlyPlayedTracksEndpoint<T> {
+impl<T: TimestampMarker + Default> RecentlyPlayedTracksEndpoint<T> {
     #[doc = include_str!("../docs/limit.md")]
     pub fn limit(mut self, limit: u32) -> Self {
         self.limit = Some(limit);
@@ -426,7 +410,7 @@ impl<T: TimestampMarker> RecentlyPlayedTracksEndpoint<T> {
     pub async fn get(
         self,
         spotify: &Client<impl AuthFlow + Authorised>,
-    ) -> Result<CursorPage<PlayHistory>> {
+    ) -> Result<CursorPage<PlayHistory, Self>> {
         spotify
             .get("/me/player/recently-played".to_owned(), self)
             .await
@@ -447,10 +431,7 @@ impl AddItemToQueueEndpoint {
     }
 
     #[doc = include_str!("../docs/send.md")]
-    pub async fn send(
-        self,
-        spotify: &Client<impl AuthFlow + Authorised>,
-    ) -> Result<Nil> {
+    pub async fn send(self, spotify: &Client<impl AuthFlow + Authorised>) -> Result<Nil> {
         spotify
             .request(
                 Method::POST,

--- a/spotify-rs/src/endpoint/user.rs
+++ b/spotify-rs/src/endpoint/user.rs
@@ -276,7 +276,7 @@ impl FollowedArtistsEndpoint {
     pub async fn get(
         self,
         spotify: &Client<impl AuthFlow + Authorised>,
-    ) -> Result<CursorPage<Artist>> {
+    ) -> Result<CursorPage<Artist, Self>> {
         spotify
             .get("/me/following".to_owned(), self)
             .await

--- a/spotify-rs/src/error.rs
+++ b/spotify-rs/src/error.rs
@@ -78,6 +78,10 @@ pub enum Error {
     /// in case.
     #[error("Internal error: the client's PKCE verifier was missing when authenticating.")]
     InvalidClientState,
+
+    // Rename the error and rewrite the description
+    #[error("There are no remaining next/previous pages to get.")]
+    NoRemainingPages,
 }
 
 #[derive(Deserialize)]

--- a/spotify-rs/src/lib.rs
+++ b/spotify-rs/src/lib.rs
@@ -1,4 +1,4 @@
-#![warn(missing_docs)]
+// #![warn(missing_docs)]
 //! spotify-rs is a Rust wrapper for the Spotify API. It has full API coverage
 //! and supports all the authorisation flows (except for the implicit grant flow).
 //!

--- a/spotify-rs/src/model.rs
+++ b/spotify-rs/src/model.rs
@@ -1,4 +1,10 @@
-use serde::{Deserialize, Deserializer};
+use crate::{
+    auth::AuthFlow,
+    client::{self, Client},
+    error::Result,
+    Error, Token,
+};
+use serde::{de::DeserializeOwned, Deserialize, Deserializer};
 
 pub mod album;
 pub mod artist;
@@ -14,23 +20,153 @@ pub mod show;
 pub mod track;
 pub mod user;
 
+/// This represents a page of items, which is a segment of data returned by the
+/// Spotify API.
+///
+/// To get the rest of the data, the fields of this struct, or, preferably,
+/// some methods can be used to get the
+/// [next](Self::get_next) or [previous](Self::get_previous) page, or
+/// the [remaining](Self::get_remaining) or [all](Self::get_all) items.
 #[derive(Clone, Debug, Deserialize, PartialEq)]
 pub struct Page<T: Clone> {
+    /// The URL to the API endpoint returning this page.
     pub href: String,
+    /// The maximum amount of items in the response.
     pub limit: u32,
+    /// The URL to the next page.
+    /// For pagination, see [`get_next`](Self::get_next).
     pub next: Option<String>,
+    /// The offset of the returned items.
     pub offset: u32,
+    /// The URL to the previous page.
+    /// For pagination, see [`get_previous`](Self::get_previous).
     pub previous: Option<String>,
+    /// The amount of returned items.
     pub total: u32,
     /// A list of the items, which includes `null` values.
     /// To get only the `Some` values, use [`filtered_items`](Self::filtered_items).
     pub items: Vec<Option<T>>,
 }
 
-impl<T: Clone> Page<T> {
+impl<T: Clone + DeserializeOwned> Page<T> {
     /// Get a list of only the `Some` values from a Page's items.
     pub fn filtered_items(&self) -> Vec<T> {
         self.items.clone().into_iter().flatten().collect()
+    }
+
+    /// Get the next page.
+    ///
+    /// If there is no next page, this will return an
+    /// [`Error::NoRemainingPages`](crate::error::Error::NoRemainingPages)
+    pub async fn get_next(&self, spotify: &Client<Token, impl AuthFlow>) -> Result<Self> {
+        let Some(next) = self.next.as_ref() else {
+            return Err(Error::NoRemainingPages);
+        };
+
+        // Remove `API_URL`from the string, as spotify.get()
+        // (or rather spotify.request) appends it already.
+        let next = next.replace(client::API_URL, "");
+
+        spotify.get::<(), _>(next, None).await
+    }
+
+    /// Get the previous page.
+    ///
+    /// If there is no previous page, this will return an
+    /// [`Error::NoRemainingPages`](crate::error::Error::NoRemainingPages)
+    pub async fn get_previous(&self, spotify: &Client<Token, impl AuthFlow>) -> Result<Self> {
+        let Some(previous) = self.previous.as_ref() else {
+            return Err(Error::NoRemainingPages);
+        };
+
+        // Remove `API_URL`from the string, as spotify.get()
+        // (or rather spotify.request) appends it already.
+        let previous = previous.replace(client::API_URL, "");
+
+        spotify.get::<(), _>(previous, None).await
+    }
+
+    /// Get the items of all the remaining pages - that is, all the pages found
+    /// after the current one.
+    pub async fn get_remaining(
+        mut self,
+        spotify: &Client<Token, impl AuthFlow>,
+    ) -> Result<Vec<Option<T>>> {
+        let mut items = std::mem::take(&mut self.items);
+        let mut page = self;
+
+        // Get all the next pages (if any)
+        if page.next.is_some() {
+            loop {
+                let next_page = page.get_next(spotify).await;
+
+                match next_page {
+                    Ok(mut p) => {
+                        items.append(&mut p.items);
+                        page = p;
+                    }
+
+                    Err(err) => match err {
+                        Error::NoRemainingPages => break,
+                        _ => return Err(err),
+                    },
+                };
+            }
+        }
+
+        Ok(items)
+    }
+
+    /// Get all of the pages - that is, all the pages found both before and
+    /// after the current one.
+    pub async fn get_all(
+        mut self,
+        spotify: &Client<Token, impl AuthFlow>,
+    ) -> Result<Vec<Option<T>>> {
+        let mut items = std::mem::take(&mut self.items);
+
+        // Get all the previous pages (if any)
+        if self.previous.is_some() {
+            let mut page = self.clone();
+
+            loop {
+                let previous_page = page.get_previous(spotify).await;
+
+                match previous_page {
+                    Ok(mut p) => {
+                        items.append(&mut p.items);
+                        page = p;
+                    }
+                    Err(err) => match err {
+                        Error::NoRemainingPages => break,
+                        _ => return Err(err),
+                    },
+                };
+            }
+        }
+
+        // Get all the next pages (if any)
+        if self.next.is_some() {
+            let mut page = self;
+
+            loop {
+                let next_page = page.get_next(spotify).await;
+
+                match next_page {
+                    Ok(mut p) => {
+                        items.append(&mut p.items);
+                        page = p;
+                    }
+
+                    Err(err) => match err {
+                        Error::NoRemainingPages => break,
+                        _ => return Err(err),
+                    },
+                };
+            }
+        }
+
+        Ok(items)
     }
 }
 
@@ -44,7 +180,7 @@ pub struct CursorPage<T: Clone> {
     pub items: Vec<Option<T>>,
 }
 
-impl<T: Clone> CursorPage<T> {
+impl<T: Clone + DeserializeOwned> CursorPage<T> {
     /// Get a list of only the `Some` values from a Cursor Page's items.
     pub fn filtered_items(&self) -> Vec<T> {
         self.items.clone().into_iter().flatten().collect()

--- a/spotify-rs/src/model/artist.rs
+++ b/spotify-rs/src/model/artist.rs
@@ -1,6 +1,8 @@
 use serde::Deserialize;
 use spotify_rs_macros::docs;
 
+use crate::endpoint::user::FollowedArtistsEndpoint;
+
 use super::*;
 
 /// An artist.
@@ -43,7 +45,7 @@ pub(crate) struct Artists {
 }
 
 // Used only to deserialize JSON responses with arrays that are named objects.
-#[derive(Clone, Debug, Deserialize, PartialEq)]
+#[derive(Clone, Debug, Deserialize)]
 pub(crate) struct PagedArtists {
-    pub(crate) artists: CursorPage<Artist>,
+    pub(crate) artists: CursorPage<Artist, FollowedArtistsEndpoint>,
 }


### PR DESCRIPTION
Added pagination to the `next` branch, in the form of methods on the `Page` and `CursorPage` structs.

This meant changing a bit of how the internal `Endpoint` trait behaves and now it has a method that returns the URL of a certain endpoint. It's currently only implemented that way for a couple of endpoints, becuase now it's required for `CursorPage` to function.

However, over time I will transition the endpoint URLs to this `endpoint_url()` trait method for consistency's sake.