### PR TITLE
derive clone for Client and CsrfVerifier

### DIFF
--- a/src/auth.rs
+++ b/src/auth.rs
@@ -99,8 +99,8 @@ pub struct ClientCredsFlow {
 
 #[derive(Debug)]
 pub struct NoVerifier;
-#[derive(Debug)]
 
+#[derive(Debug, Clone)]
 pub struct CsrfVerifier(pub(crate) CsrfToken);
 
 #[derive(Debug)]

--- a/src/client.rs
+++ b/src/client.rs
@@ -78,7 +78,7 @@ pub(crate) enum Body<P: Serialize = ()> {
 ///
 /// It is recommended to use one of the following: [`AuthCodeClient`], [`AuthCodePkceClient`] or [`ClientCredsClient`],
 /// depending on the chosen auth flow.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Client<A: AuthenticationState, F: AuthFlow, V: Verifier> {
     /// Dictates whether or not the client will request a new token when the
     /// current one is about the expire.


### PR DESCRIPTION
When using the client in a route handler e.g. with axum it would be useful to just clone the client and therefore the CsrfVerifier