### PR TITLE
Fix AuthCodeClient::from_access_token() for new clients

### DIFF
--- a/spotify-rs/src/client.rs
+++ b/spotify-rs/src/client.rs
@@ -554,7 +554,7 @@ impl AuthCodeClient<Token> {
 
         // This is just a bogus request to check if the token is valid.
         let res = http
-            .get(format!("{API_URL}/recommendations/available-genre-seeds"))
+            .get(format!("{API_URL}/markets"))
             .bearer_auth(token.secret())
             .header(CONTENT_LENGTH, 0)
             .send()


### PR DESCRIPTION
Hi, I started using spotify-rs but hit a snag when trying to save and reuse tokens.

The request to test access in from_access_token() was returning 404. The requested URL, `/recommendations/available-genre-seeds`, is not available to new web API clients since 2024-11-27, as per https://developer.spotify.com/blog/2024-11-27-changes-to-the-web-api .

The request is therefore changed to `/markets` in this PR, is I don't think that it will become restricted.
https://developer.spotify.com/documentation/web-api/reference/get-available-markets

`dbg!(&res)` from `from_access_token()` output is shown below. Notice the status field.

**Before fix**

```
2025-06-20T18:48:11.758560Z ERROR spotify_rs::client: check token result
[spotify-rs/spotify-rs/src/client.rs:565:13] &res = Response {
    url: Url {
        scheme: "https",
        cannot_be_a_base: false,
        username: "",
        password: None,
        host: Some(
            Domain(
                "api.spotify.com",
            ),
        ),
        port: None,
        path: "/v1/recommendations/available-genre-seeds",
        query: None,
        fragment: None,
    },
    status: 404,
    headers: {
        "cache-control": "private, max-age=0",
        "access-control-allow-origin": "*",
        "access-control-allow-headers": "Accept, App-Platform, Authorization, Content-Type, Origin, Retry-After, Spotify-App-Version, X-Cloud-Trace-Context, client-token, content-access-token",
        "access-control-allow-methods": "GET, POST, OPTIONS, PUT, DELETE, PATCH",
        "access-control-allow-credentials": "true",
        "access-control-max-age": "604800",
        "content-length": "0",
        "strict-transport-security": "max-age=31536000",
        "x-content-type-options": "nosniff",
        "alt-svc": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
        "alt-svc": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
        "date": "Fri, 20 Jun 2025 18:48:11 GMT",
        "server": "envoy",
        "via": "HTTP/2 edgeproxy, 1.1 google",
    },
}
2025-06-20T18:48:11.759151Z ERROR spotify_rs::client: res is not success
```

**With fix**

```
2025-06-20T19:04:55.391400Z ERROR spotify_rs::client: check token result
[spotify-rs/spotify-rs/src/client.rs:564:9] &res = Response {
    url: Url {
        scheme: "https",
        cannot_be_a_base: false,
        username: "",
        password: None,
        host: Some(
            Domain(
                "api.spotify.com",
            ),
        ),
        port: None,
        path: "/v1/markets",
        query: None,
        fragment: None,
    },
    status: 200,
    headers: {
        "content-type": "application/json; charset=utf-8",
        "cache-control": "public, max-age=0",
        "etag": "[redacted by me]",
        "x-robots-tag": "noindex, nofollow",
        "access-control-allow-origin": "*",
        "access-control-allow-headers": "Accept, App-Platform, Authorization, Content-Type, Origin, Retry-After, Spotify-App-Version, X-Cloud-Trace-Context, client-token, content-access-token",
        "access-control-allow-methods": "GET, POST, OPTIONS, PUT, DELETE, PATCH",
        "access-control-allow-credentials": "true",
        "access-control-max-age": "604800",
        "content-length": "938",
        "strict-transport-security": "max-age=31536000",
        "x-content-type-options": "nosniff",
        "alt-svc": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
        "alt-svc": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
        "vary": "Accept-Encoding",
        "date": "Fri, 20 Jun 2025 19:04:55 GMT",
        "server": "envoy",
        "via": "HTTP/2 edgeproxy, 1.1 google",
    },
}
2025-06-20T19:04:55.393605Z ERROR spotify_rs::client: res is success
```

**With fix, after waiting 1 hour before using the token**

```
2025-06-20T19:34:38.445609Z TRACE hyper::proto::h1::conn: flushed({role=client}): State { reading: Init, writing: Init, keep_alive: Idle }
[spotify-rs/spotify-rs/src/client.rs:564:9] &res = Response {
    url: Url {
        scheme: "https",
2025-06-20T19:34:38.445650Z TRACE hyper::client::pool: put; add idle connection for ("https", api.spotify.com)
        cannot_be_a_base: false,
        username: "2025-06-20T19:34:38.445715Z DEBUG hyper::client::pool: pooling idle connection for ("https", api.spotify.com)
",
        password: None,
        host: Some(
            Domain(
                "api.spotify.com",
            ),
        ),
        port: None,
        path: "/v1/markets",
        query: None,
        fragment: None,
    },
    status: 401,
    headers: {
        "www-authenticate": "Bearer realm=\"spotify\", error=\"invalid_token\", error_description=\"The access token expired\"",
        "access-control-allow-origin": "*",
        "access-control-allow-headers": "Accept, App-Platform, Authorization, Content-Type, Origin, Retry-After, Spotify-App-Version, X-Cloud-Trace-Context, client-token, content-access-token",
        "access-control-allow-methods": "GET, POST, OPTIONS, PUT, DELETE, PATCH",
        "access-control-allow-credentials": "true",
        "access-control-max-age": "604800",
        "content-type": "application/json",
        "content-length": "81",
        "strict-transport-security": "max-age=31536000",
        "x-content-type-options": "nosniff",
        "alt-svc": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
        "alt-svc": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
        "vary": "Accept-Encoding",
        "date": "Fri, 20 Jun 2025 19:34:38 GMT",
        "server": "envoy",
        "via": "HTTP/2 edgeproxy, 1.1 google",
    },
}

```