### PR TITLE
readme: Fix link to examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     Ok(())
 }
 ```
-You can find more examples in the [examples](examples) directory.
+You can find more examples in the [examples](spotify-rs/examples) directory.
 Detailed information is available in the [API documentation](https://docs.rs/spotify-rs/).
 
 ## License


### PR DESCRIPTION
Fixes the readme link to the examples. Likely broke when spotify-rs-macros was set up.