### PR TITLE
Fix token refresh for from_refresh_token() client

### DIFF
--- a/spotify-rs/src/client.rs
+++ b/spotify-rs/src/client.rs
@@ -107,7 +107,12 @@ impl Client<Token, UnknownFlow> {
             req = req.add_scopes(scopes.0);
         }
 
-        let token = req.request_async(async_http_client).await?.set_timestamps();
+        let mut token = req.request_async(async_http_client).await?.set_timestamps();
+        if token.refresh_token.is_none() {
+            // "When a refresh token is not returned, continue using the existing token."
+            // https://developer.spotify.com/documentation/web-api/tutorials/refreshing-tokens
+            token.refresh_token = Some(refresh_token);
+        }
 
         Ok(Self {
             auto_refresh,


### PR DESCRIPTION
The Spotify API does not return a refresh token when authenticating using a refresh token, so the client already has to store the refresh token provided to from_refresh_token().


Without this fix, the code would stop after `spotify_rs::client: The token has expired, attempting to refresh...`