### PR TITLE
Properly update refresh and auth token in long-running process

### DIFF
--- a/spotify-rs/src/client.rs
+++ b/spotify-rs/src/client.rs
@@ -203,7 +203,7 @@ impl<F: AuthFlow> Client<Token, F> {
         query: Option<P>,
         body: Option<Body<P>>,
     ) -> Result<T> {
-        let (token_expired, secret) = {
+        let (token_expired, mut secret) = {
             let lock = self
                 .auth_state
                 .read()
@@ -222,6 +222,7 @@ impl<F: AuthFlow> Client<Token, F> {
                     .auth_state
                     .read()
                     .expect("The lock holding the token has been poisoned.");
+                secret = lock.access_token.secret().to_owned();
 
                 info!("The token has been successfully refreshed. The new token will expire in {} seconds", lock.expires_in);
             } else {

--- a/spotify-rs/src/client.rs
+++ b/spotify-rs/src/client.rs
@@ -178,12 +178,15 @@ impl<F: AuthFlow> Client<Token, F> {
             refresh_token.clone()
         };
 
-        let token = self
+        let mut token = self
             .oauth
             .exchange_refresh_token(&refresh_token)
             .request_async(async_http_client)
             .await?
             .set_timestamps();
+        if token.refresh_token.is_none() {
+            token.refresh_token = Some(refresh_token);
+        }
 
         let mut lock = self
             .auth_state


### PR DESCRIPTION
Follow-up on PR #23 and issue #24.

Handles that the Spotify API for some auth flows (it's unclear) does not return a refresh token.

The code change also uses the newly acquired auth token, after a refresh, when doing subsequent requests. The main code would fail with "401 The access token expired" due to the old expired auth token being used just after a refresh. The problem might not have shown up if a new auth token was requested long before the old auth token expired.


The test code in #24 was run for 12h without any problems.